### PR TITLE
Heroku Setup and Enforce SSL

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 ---
 plugins:
+  - rubocop-minitest
   - rubocop-performance
   - rubocop-rake
 

--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem 'pry'
 # development
 group :development do
   gem 'rubocop'
+  gem 'rubocop-minitest'
   gem 'rubocop-performance'
   gem 'rubocop-rake', '~> 0.7.1'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,14 @@ gem 'slim'
 
 # configuration
 gem 'figaro'
+gem 'rake'
+
+# communication
+gem 'http'
+
+# security
+gem 'rack-ssl-enforcer'
+gem 'rbnacl' # assumes libsodium package already installed
 
 # encoding
 gem 'base64'
@@ -19,18 +27,18 @@ gem 'base64'
 # debugging
 gem 'pry'
 
-# communication
-gem 'http'
-
-# security
-gem 'rbnacl' # assumes libsodium package already installed
-
 # development
 group :development do
-  gem 'rake'
   gem 'rubocop'
   gem 'rubocop-performance'
   gem 'rubocop-rake', '~> 0.7.1'
+end
+
+# testing
+group :test do
+  gem 'minitest'
+  gem 'minitest-rg'
+  gem 'webmock'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,11 @@ GEM
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.3)
     base64 (0.2.0)
+    bigdecimal (3.1.9)
     coderay (1.1.3)
+    crack (1.0.0)
+      bigdecimal
+      rexml
     domain_name (0.6.20240107)
     ffi (1.17.2)
     ffi (1.17.2-aarch64-linux-gnu)
@@ -23,6 +27,7 @@ GEM
       rake
     figaro (1.2.0)
       thor (>= 0.14.0, < 2)
+    hashdiff (1.1.2)
     http (5.2.0)
       addressable (~> 2.8)
       base64 (~> 0.1)
@@ -42,6 +47,9 @@ GEM
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
     method_source (1.1.0)
+    minitest (5.25.5)
+    minitest-rg (5.3.0)
+      minitest (~> 5.0)
     nio4r (2.7.4)
     parallel (1.27.0)
     parser (3.3.8.0)
@@ -59,6 +67,7 @@ GEM
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
+    rack-ssl-enforcer (0.2.9)
     rack-test (2.2.0)
       rack (>= 1.3)
     rainbow (3.1.1)
@@ -71,6 +80,7 @@ GEM
     regexp_parser (2.10.0)
     rerun (0.14.0)
       listen (~> 3.0)
+    rexml (3.4.1)
     roda (3.91.0)
       rack
     rubocop (1.75.4)
@@ -104,6 +114,10 @@ GEM
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
+    webmock (3.25.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
   aarch64-linux-gnu
@@ -115,6 +129,7 @@ PLATFORMS
   x86-linux-gnu
   x86-linux-musl
   x86_64-darwin
+  x86_64-linux
   x86_64-linux-gnu
   x86_64-linux-musl
 
@@ -122,10 +137,13 @@ DEPENDENCIES
   base64
   figaro
   http
+  minitest
+  minitest-rg
   pry
   puma
   rack (>= 3.1.14)
   rack-session (>= 2.1.1)
+  rack-ssl-enforcer
   rack-test
   rake
   rbnacl
@@ -135,6 +153,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rake (~> 0.7.1)
   slim
+  webmock
 
 RUBY VERSION
    ruby 3.4.3p32

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,10 @@ GEM
     rubocop-ast (1.44.1)
       parser (>= 3.3.7.2)
       prism (~> 1.4)
+    rubocop-minitest (0.38.0)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.75.0, < 2.0)
+      rubocop-ast (>= 1.38.0, < 2.0)
     rubocop-performance (1.25.0)
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
@@ -125,7 +129,6 @@ PLATFORMS
   arm-linux-gnu
   arm-linux-musl
   arm64-darwin
-  ruby
   x86-linux-gnu
   x86-linux-musl
   x86_64-darwin
@@ -150,6 +153,7 @@ DEPENDENCIES
   rerun
   roda
   rubocop
+  rubocop-minitest
   rubocop-performance
   rubocop-rake (~> 0.7.1)
   slim

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec puma -t 5:5 -p ${PORT:-3000} -e ${RACK_ENV:-development}

--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ bundle install
 
 ## Test
 
-This web app does not contain any tests yet, so sad T_T
+Run the test specification script in `Rakefile`:
+
+```
+rake spec
+```
 
 ## Execute
 
@@ -25,3 +29,10 @@ rake run:dev
 ```
 
 The application expects the API application to also be running (see `config/secrets_example.yml` for specifying its URL)
+
+## Release Check
+Before submitting pull requests, please check if specs, style, and dependency audits pass (will need to be online to update dependency database):
+
+```
+rake release?
+```

--- a/config/environments.rb
+++ b/config/environments.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
+require 'delegate'
 require 'roda'
 require 'figaro'
 require 'logger'
+require 'rack/ssl-enforcer'
 require 'rack/session'
+
+require_relative '../require_app'
 
 module UCCMe
   # Configuration for the APP
@@ -18,12 +22,6 @@ module UCCMe
     Figaro.load
     def self.config = Figaro.env
 
-    # Sesssion configuration
-    ONE_MONTH = 60 * 60 * 24 * 30
-    use Rack::Session::Cookie,
-        expire_after: ONE_MONTH,
-        secret: config.SESSION_SECRET
-
     # HTTP Request logging
     configure :development, :production do
       plugin :common_logger, $stdout
@@ -33,6 +31,12 @@ module UCCMe
     LOGGER = Logger.new($stderr)
     def self.logger = LOGGER
 
+    # Sesssion configuration
+    ONE_MONTH = 60 * 60 * 24 * 30
+    use Rack::Session::Cookie,
+        expire_after: ONE_MONTH,
+        secret: config.SESSION_SECRET
+
     # Console/Pry configuration
     configure :development, :test do
       require 'pry'
@@ -41,6 +45,10 @@ module UCCMe
       def self.reload!
         exec 'pry -r ./spec/test_load_all'
       end
+    end
+
+    configure :production do
+      use Rack::SslEnforcer, hsts: true
     end
   end
 end

--- a/config/secrets_example.yml
+++ b/config/secrets_example.yml
@@ -10,3 +10,8 @@ test:
   API_URL: http://localhost:3000/api/v1
   APP_URL: http://localhost:9292
   SESSION_SECRET: your_session_secret_key
+
+production:
+  API_URL: <provisioned API URL (ending with api/[version])>
+  APP_URL: <provisioned app URL (root without ending slash)>
+  SESSION_SECRET: your_session_secret_key

--- a/rakefile
+++ b/rakefile
@@ -11,9 +11,38 @@ task console: :print_env do
   sh 'pry -r ./spec/test_load_all'
 end
 
-desc 'Rake all the ruby'
-task :style do
+desc 'Test all the specs'
+Rake::TestTask.new(:spec) do |t|
+  t.pattern = 'spec/**/*_spec.rb'
+  t.warning = false
+end
+
+desc 'Rerun tests on live code changes'
+task :respec do
+  sh 'rerun -c rake spec'
+end
+
+desc 'Rake rubocop to check style'
+task style: :spec do
   sh 'rubocop .'
+end
+
+desc 'Update vulnerabilities lit and audit gems'
+task :audit do
+  sh 'bundle audit check --update'
+end
+
+desc 'Checks for release'
+task release?: %i[spec style audit] do
+  puts "\nReady for release!"
+end
+
+namespace :run do
+  # Run in development mode
+  desc 'Run Web App in development mode'
+  task dev: :print_env do
+    sh 'puma -p 9292'
+  end
 end
 
 # Generate new cryptographic keys
@@ -25,13 +54,5 @@ namespace :generate do
     session_secret = RbNaCl::Random.random_bytes(64)
     secret64 = Base64.strict_encode64(session_secret)
     puts "New SESSION_SECRET (base64): #{secret64}"
-  end
-end
-
-namespace :run do
-  # Run in development mode
-  desc 'Run Web App in development mode'
-  task dev: :print_env do
-    sh 'puma -p 9292'
   end
 end

--- a/spec/integration/service_authenticate_spec.rb
+++ b/spec/integration/service_authenticate_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require_relative '../spec_helper'
+require 'webmock/minitest'
+
+describe 'Test Service Objects' do
+  before do
+    @owners = { username: 'shou', password: 'shouliu' }
+    @mal_accounts = { username: 'shou', password: 'wrongpassword' }
+    @api_account = { attributes:
+                      { username: 'shou', email: 'shou.liu@gmail.com' } }
+  end
+
+  after do
+    WebMock.reset!
+  end
+
+  describe 'Find authenticated account' do
+    it 'HAPPY: should find an authenticated account' do
+      WebMock.stub_request(:post, "#{API_URL}/auth/authenticate")
+             .with(body: @owners.to_json)
+             .to_return(body: @api_account.to_json,
+                        headers: { 'Content-Type' => 'application/json' })
+
+      account = UCCMe::AuthenticateAccount.new(app.config).call(**@owners)
+      _(account).wont_be_nil
+      _(account['username']).must_equal @api_account[:attributes][:username]
+      _(account['email']).must_equal @api_account[:attributes][:email]
+    end
+
+    it 'BAD: should not find a false authenticated account' do
+      WebMock.stub_request(:post, "#{API_URL}/auth/authenticate")
+             .with(body: @mal_accounts.to_json)
+             .to_return(status: 403)
+      _(proc {
+        UCCMe::AuthenticateAccount.new(app.config).call(**@mal_accounts)
+      }).must_raise UCCMe::AuthenticateAccount::UnauthorizedError
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+ENV['RACK_ENV'] = 'test'
+
+require 'minitest/autorun'
+require 'minitest/rg'
+
+require_relative 'test_load_all'
+
+API_URL = app.config.API_URL


### PR DESCRIPTION
- [x]  App: Strengthening our Web Application

 - (optional) Use WebMock to write basic tests for your Web Application’s services
 - Use the rack-ssl-enforcer gem to redirect users to HTTPS connections in production only

- [x] Deploy your App to Heroku